### PR TITLE
Fix for php8 Fatal Error

### DIFF
--- a/src/includes/defaults/triggers.php
+++ b/src/includes/defaults/triggers.php
@@ -14,8 +14,8 @@ $cached_post_types = notification_cache( 'post_types' );
 if ( $post_types ) {
 	foreach ( $post_types as $post_type ) {
 
-		// Skip if the post type cache wasn't set.
-		if ( ! array_key_exists( $post_type, $cached_post_types ) ) {
+		// Skip if the post type cache wasn't set or is not an array.
+		if ( !is_array($cached_post_types) || ! array_key_exists( $post_type, $cached_post_types ) ) {
 			continue;
 		}
 


### PR DESCRIPTION
Php 8 is returning a Fatal Error if $cached_post_types is not an array.